### PR TITLE
Remove excluded resources causing warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,5 @@ project.xcworkspace/
 /.swiftpm
 /Vendor/antlr4-graphql-grammar
 /antlr4.jar
-GraphQL.interp
-GraphQL.tokens
-GraphQLLexer.interp
-GraphQLLexer.tokens
+/Sources/GraphQLLanguage/Generated/*.interp
+/Sources/GraphQLLanguage/Generated/*.tokens

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ project.xcworkspace/
 /.swiftpm
 /Vendor/antlr4-graphql-grammar
 /antlr4.jar
+GraphQL.interp
+GraphQL.tokens
+GraphQLLexer.interp
+GraphQLLexer.tokens

--- a/Package.swift
+++ b/Package.swift
@@ -23,12 +23,6 @@ let package = Package(
             name: "GraphQLLanguage",
             dependencies: [
                 .target(name: "Antlr4")
-            ],
-            exclude: [
-                "Generated/GraphQL.interp",
-                "Generated/GraphQL.tokens",
-                "Generated/GraphQLLexer.interp",
-                "Generated/GraphQLLexer.tokens"
             ]),
         .target(
             name: "Antlr4",


### PR DESCRIPTION
These excluded files are generating warnings while parsing GraphQL documents because they are not found at that stage in the process. Instead of excluding them in the Package manifest, they can be git-ignored.