### PR TITLE
Allow for rewriting operations to throw errors

### DIFF
--- a/Sources/GraphQLLanguage/Visitor.swift
+++ b/Sources/GraphQLLanguage/Visitor.swift
@@ -8,19 +8,19 @@
 public typealias Visitable = LanguageNode
 
 public protocol Visitor {
-    func visit(on visitable: Visitable)
+    func visit(on visitable: Visitable) throws
 }
 
 private struct BlockVisitor: Visitor {
     var block: (Visitable) -> Void
 
-    func visit(on visitable: Visitable) {
+    func visit(on visitable: Visitable) throws {
         block(visitable)
     }
 }
 
 extension Visitable {
-    public func visit(with visitor: Visitor) {
+    public func visit(with visitor: Visitor) throws {
         // Use reflection to depth-first traverse `Visitable`.
         let mirror = Mirror(reflecting: self)
 
@@ -41,24 +41,24 @@ extension Visitable {
             // These are known child field representation in each `Visitable`
             switch childValue {
             case let visitable as Visitable:
-                visitable.visit(with: visitor)
+                try visitable.visit(with: visitor)
             case let array as [Visitable]:
                 for visitable in array {
-                    visitable.visit(with: visitor)
+                    try visitable.visit(with: visitor)
                 }
             // See `ObjectValue`
             case let dictionary as [String: Visitable]:
                 for (_, visitable) in dictionary {
-                    visitable.visit(with: visitor)
+                    try visitable.visit(with: visitor)
                 }
             default:
                 break
             }
         }
-        visitor.visit(on: self)
+        try visitor.visit(on: self)
     }
 
-    public func visit(with visitor: @escaping (Visitable) -> Void) {
-        visit(with: BlockVisitor(block: visitor))
+    public func visit(with visitor: @escaping (Visitable) -> Void) throws {
+        try visit(with: BlockVisitor(block: visitor))
     }
 }

--- a/Sources/GraphQLLanguage/Visitor.swift
+++ b/Sources/GraphQLLanguage/Visitor.swift
@@ -12,10 +12,10 @@ public protocol Visitor {
 }
 
 private struct BlockVisitor: Visitor {
-    var block: (Visitable) -> Void
+    var block: (Visitable) throws -> Void
 
     func visit(on visitable: Visitable) throws {
-        block(visitable)
+        try block(visitable)
     }
 }
 
@@ -58,7 +58,7 @@ extension Visitable {
         try visitor.visit(on: self)
     }
 
-    public func visit(with visitor: @escaping (Visitable) -> Void) throws {
+    public func visit(with visitor: @escaping (Visitable) throws -> Void) throws {
         try visit(with: BlockVisitor(block: visitor))
     }
 }

--- a/Tests/GraphQLLanguageTests/RewriterTest.swift
+++ b/Tests/GraphQLLanguageTests/RewriterTest.swift
@@ -68,7 +68,7 @@ final class RewriterTest: XCTestCase {
         }
 
         do {
-            _ = try document.rewrite { rewritable in
+            _ = try document.rewrite { _ in
                 throw Foo.bar
             }
             XCTFail("Expected exception")

--- a/Tests/GraphQLLanguageTests/RewriterTest.swift
+++ b/Tests/GraphQLLanguageTests/RewriterTest.swift
@@ -58,4 +58,26 @@ final class RewriterTest: XCTestCase {
 
         XCTAssertEqual(result, "meow")
     }
+
+    func testThrowingRewriter() throws {
+        let source = Source(string: "type Cat")
+        let document = try Document.parsing(source)
+
+        enum Foo: Error {
+            case bar
+        }
+
+        do {
+            _ = try document.rewrite { rewritable in
+                throw Foo.bar
+            }
+            XCTFail("Expected exception")
+        }
+        catch Foo.bar {
+            // Pass
+        }
+        catch {
+            XCTFail("Expected Foo.bar, got \(error)")
+        }
+    }
 }

--- a/Tests/GraphQLLanguageTests/VisitorTest.swift
+++ b/Tests/GraphQLLanguageTests/VisitorTest.swift
@@ -29,4 +29,26 @@ final class VisitorTest: XCTestCase {
             "Document"
         ])
     }
+
+    func testThrowingVisitor() throws {
+        let source = Source(string: "type Cat")
+        let document = try Document.parsing(source)
+
+        enum Foo: Error {
+            case bar
+        }
+
+        do {
+            _ = try document.visit { _ in
+                throw Foo.bar
+            }
+            XCTFail("Expected exception")
+        }
+        catch Foo.bar {
+            // Pass
+        }
+        catch {
+            XCTFail("Expected Foo.bar, got \(error)")
+        }
+    }
 }

--- a/Tests/GraphQLLanguageTests/VisitorTest.swift
+++ b/Tests/GraphQLLanguageTests/VisitorTest.swift
@@ -14,7 +14,7 @@ final class VisitorTest: XCTestCase {
         let document = try Document.parsing(source)
 
         var visited: [Visitable] = []
-        document.visit { visitable in
+        try document.visit { visitable in
             visited.append(visitable)
         }
 


### PR DESCRIPTION
When using `GraphQLLanguage` to parse and rewrite GraphQL documents, it has come the need to support throwing exceptions when rewrite operations cannot be complete or fail.

To achieve this, both `Rewriter` and `Visitable` protocols have to be updated, together with the methods involved in the process, so exceptions can be thrown up the chain.