### PR TITLE
Crash when getting `BuildError.debugDescription`

### DIFF
--- a/Tests/GraphQLLanguageTests/ParsingTest.swift
+++ b/Tests/GraphQLLanguageTests/ParsingTest.swift
@@ -14,4 +14,10 @@ final class ParsingTest: XCTestCase {
 
         XCTAssertNoThrow(try Document.parsing(source))
     }
+
+    func testUnexpectedContext() {
+        let source = Source(string: "query { cat(age: \(Int(Int32.max) + 1)) }")
+
+        XCTAssertThrowsError(try Document.parsing(source))
+    }
 }


### PR DESCRIPTION
Instead of capturing the context, `BuildError.unexpectedContext` captures only what's necessary to generate the error message. This prevents a crash `Thread 1: Fatal error: Unexpectedly found nil while unwrapping an Optional value`.